### PR TITLE
Django 1.5 upgrade cleanup

### DIFF
--- a/django_badbrowser/templates/django_badbrowser/unsupported.html
+++ b/django_badbrowser/templates/django_badbrowser/unsupported.html
@@ -132,7 +132,7 @@ p {
 		{% endblock %}
 		
 		{% block unsupported_ignore %}
-		<p id="ignore">You may <a href="{% url django-badbrowser-ignore %}?next={{ next|urlencode }}">ignore this warning</a> at your own peril.</p>
+		<p id="ignore">You may <a href="{% url "django-badbrowser-ignore" %}?next={{ next|urlencode }}">ignore this warning</a> at your own peril.</p>
 		{% endblock %}
 	</div>
 	


### PR DESCRIPTION
For Django 1.5 the argument to "url" must be in double quotes or an error is presented to the browser.
